### PR TITLE
Version 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 1.2.0
+- Make optional to require that the Comprobante contains the TimbreFiscalDigital.
+  This is useful to validate before obtaining the TimbreFiscalDigital from an
+  authorized third party.
+
 # Version 1.1.1
 - Improved code coverage, thanks to pull request #5 by @driftking301
 - Sort assets by cfdi version

--- a/tests/CFDIReaderTests/Scripts/ValidateTest.php
+++ b/tests/CFDIReaderTests/Scripts/ValidateTest.php
@@ -91,7 +91,7 @@ class ValidateTest extends TestCase
         new Validate('', [''], '', null);
     }
 
-    public function testRunExpectUUID()
+    public function testRunExpectUUID32()
     {
         $validate = $this->makeValidateObject([
             test_file_location('v32/valid.xml'),
@@ -101,6 +101,18 @@ class ValidateTest extends TestCase
         $this->assertCount(1, $validate->messages);
         $this->assertCount(1, $validate->writes);
         $this->assertContains('UUID: e403f396-6a57-4625-adb4-bb436b00789f', $validate->writes[0]);
+    }
+
+    public function testRunExpectUUID33()
+    {
+        $validate = $this->makeValidateObject([
+            test_file_location('v33/valid.xml'),
+        ]);
+        $validate->run();
+
+        $this->assertCount(1, $validate->messages);
+        $this->assertCount(1, $validate->writes);
+        $this->assertContains('UUID: 9FB6ED1A-5F37-4FEF-980A-7F8C83B51894', $validate->writes[0]);
     }
 
     public function testRunExpectErrorEmptyFilename()

--- a/tests/assets/v33/valid.xml
+++ b/tests/assets/v33/valid.xml
@@ -1,5 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<cfdi:Comprobante xmlns:cfdi="http://www.sat.gob.mx/cfd/3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sat.gob.mx/cfd/3 http://www.sat.gob.mx/sitio_internet/cfd/3/cfdv33.xsd" Version="3.3" Serie="A" Folio="167ABC" Fecha="2017-01-05T09:09:23" Sello="" NoCertificado="20001000000200001428" Certificado="" SubTotal="1000" Moneda="MXN" Total="1500" TipoDeComprobante="I" FormaPago="01" MetodoPago="PUE" CondicionesDePago="CONDICIONES" Descuento="0.00" TipoCambio="1.0" LugarExpedicion="45079">
+<cfdi:Comprobante
+        xmlns:cfdi="http://www.sat.gob.mx/cfd/3"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.sat.gob.mx/cfd/3 http://www.sat.gob.mx/sitio_internet/cfd/3/cfdv33.xsd"
+        Version="3.3"
+        Serie="A"
+        Folio="167ABC"
+        Fecha="2017-01-05T09:09:23"
+        Sello=""
+        NoCertificado="20001000000200001428"
+        Certificado=""
+        SubTotal="2269400"
+        Moneda="MXN"
+        Total="2382870"
+        TipoDeComprobante="I"
+        FormaPago="01"
+        MetodoPago="PUE"
+        CondicionesDePago="CONDICIONES"
+        Descuento="0.00"
+        TipoCambio="1.0"
+        LugarExpedicion="45079">
   <cfdi:CfdiRelacionados TipoRelacion="01">
     <cfdi:CfdiRelacionado UUID="A39DA66B-52CA-49E3-879B-5C05185B0EF7"/>
   </cfdi:CfdiRelacionados>
@@ -12,7 +32,7 @@
           <cfdi:Traslado Base="2250000" Impuesto="001" TipoFactor="Tasa" TasaOCuota="0.160000" Importe="360000"/>
         </cfdi:Traslados>
         <cfdi:Retenciones>
-          <cfdi:Retencion Base="2250000" Impuesto="002" TipoFactor="Tasa" TasaOCuota="0.530000" Importe="247500"/>
+          <cfdi:Retencion Base="2250000" Impuesto="002" TipoFactor="Tasa" TasaOCuota="0.110000" Importe="247500"/>
         </cfdi:Retenciones>
       </cfdi:Impuestos>
       <cfdi:CuentaPredial Numero="51888"/>
@@ -23,7 +43,7 @@
           <cfdi:Traslado Base="2400" Impuesto="001" TipoFactor="Tasa" TasaOCuota="0.160000" Importe="384"/>
         </cfdi:Traslados>
         <cfdi:Retenciones>
-          <cfdi:Retencion Base="2400" Impuesto="002" TipoFactor="Tasa" TasaOCuota="0.530000" Importe="264"/>
+          <cfdi:Retencion Base="2400" Impuesto="002" TipoFactor="Tasa" TasaOCuota="0.110000" Importe="264"/>
         </cfdi:Retenciones>
       </cfdi:Impuestos>
       <cfdi:InformacionAduanera NumeroPedimento="15  48  4567  6001234"/>
@@ -31,10 +51,10 @@
     <cfdi:Concepto ClaveProdServ="01010101" ClaveUnidad="F52" NoIdentificacion="00003" Cantidad="1.7" Unidad="TONELADA" Descripcion="ZAMAC" ValorUnitario="10000" Importe="17000">
       <cfdi:Impuestos>
         <cfdi:Traslados>
-          <cfdi:Traslado Base="17000" Impuesto="001" TipoFactor="Tasa" TasaOCuota="0.530000" Importe="2720"/>
+          <cfdi:Traslado Base="17000" Impuesto="001" TipoFactor="Tasa" TasaOCuota="0.160000" Importe="2720"/>
         </cfdi:Traslados>
         <cfdi:Retenciones>
-          <cfdi:Retencion Base="17000" Impuesto="002" TipoFactor="Tasa" TasaOCuota="0.160000" Importe="1870"/>
+          <cfdi:Retencion Base="17000" Impuesto="002" TipoFactor="Tasa" TasaOCuota="0.110000" Importe="1870"/>
         </cfdi:Retenciones>
       </cfdi:Impuestos>
       <cfdi:Parte ClaveProdServ="01010101" NoIdentificacion="055155" Cantidad="1.0" Descripcion="PARTE EJEMPLO" Unidad="UNIDAD" ValorUnitario="1.00" Importe="1.00">
@@ -42,12 +62,12 @@
       </cfdi:Parte>
     </cfdi:Concepto>
   </cfdi:Conceptos>
-  <cfdi:Impuestos TotalImpuestosRetenidos="247500" TotalImpuestosTrasladados="360000">
+  <cfdi:Impuestos TotalImpuestosRetenidos="249634" TotalImpuestosTrasladados="363104">
     <cfdi:Retenciones>
-      <cfdi:Retencion Impuesto="002" Importe="247500"/>
+      <cfdi:Retencion Impuesto="002" Importe="249634"/>
     </cfdi:Retenciones>
     <cfdi:Traslados>
-      <cfdi:Traslado Impuesto="001" TipoFactor="Tasa" TasaOCuota="0.160000" Importe="360000"/>
+      <cfdi:Traslado Impuesto="001" TipoFactor="Tasa" TasaOCuota="0.160000" Importe="363104"/>
     </cfdi:Traslados>
   </cfdi:Impuestos>
   <cfdi:Complemento>


### PR DESCRIPTION
- Make optional to require that the Comprobante contains the TimbreFiscalDigital. 
  This is useful to validate before obtaining the TimbreFiscalDigital from an 
  authorized third party.
- Minor version change since `CFDIReader::__construct` changed.
  It is compatible with previous versions, so it will not introduce break changes.