### PR TITLE
Version 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ This project is using Semantic Versioning, meaning that a version is: MAJOR.MINO
 - Create a new post validator `\CFDIReader\PostValidations\Validators\Certificado` that checks:
     - certificate number match (error)
     - emisor rfc match  (error)
-    - emisor name match  (warning)
+    - emisor nombre match  (warning)
     - date between certificate dates (error)
     - if contains a CadenaOrigen object, verify that the sello match with the "cadena de origen" using
       the public key certificate (error). If this tails then the CFDI was modified.
-- Add dependency on `eclipxe/CfdiUtils` to be avble to create the "Cadena Origen" and recover
+- Add dependency on `eclipxe/CfdiUtils` to be able to create the "Cadena Origen" and recover
   a certificate from a cfdi.
 - Add new methods on `CFDIReader\CFDIFactory` to create helper objects:
     - `newXsltRetriever(DownloaderInterface $downloader = null): ?XsltRetriever`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@ This project is using Semantic Versioning, meaning that a version is: MAJOR.MINO
   - MINOR version when you add functionality in a backwards-compatible manner, and
   - PATCH version when you make backwards-compatible bug fixes.
 
+# Version 2.3.0 - node and attribute
+- Add `node` and `attribute` methods to `CFDIReader`.
+  This action simplify the information extraction from the comprobante.
+  - `nodes` returns `NULL` or a cloned `\SimpleXmlElement`
+  - `attribute` returns a string
+- Refactor validators and `CFDIReader` to use this helpers, now is more readable and simple
+- Fix possible bug when `CFDIFactory::newXsltRetriever()` returns `NULL`
+- Fix possible bug inside `CFDICleaner::xpathQuery()` when `\DOMXPath::query` returns `FALSE`
+- Fix dockblocks of object type properties that allows nulls
+- Special thanks to `phpstan/phpstan` to help me catch possible bugs
+
 # Version 2.2.0 - Validate certificate
 - Create a new post validator `\CFDIReader\PostValidations\Validators\Certificado` that checks:
     - certificate number match (error)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ The `CFDIReader` class is immutable, it only perform the following checks:
 * If required, the namespaces could must include http://www.sat.gob.mx/TimbreFiscalDigital
   and the element Comprobante/Complemento/TimbreFiscalDigital must exists
 
+### CFDIReader helper functions
+
+`\CFDIReader\CFDIReader::node`: Help you to retrieve an specific node, returns `NULL` if not found.
+i. e. `$cfdi->node('conceptos', 'concepto')` will return the list of `Complemento/Conceptos/Concepto` nodes.
+
+`\CFDIReader\CFDIReader::attribute`: Help you to retrieve an specific attribute inside a node,
+returns an empry string if the node or the attribute was not found.
+i. e. `$cfdi->node('emisor', 'nombre')` will return something like `'Empresa de ejemplo SA de CV'`.
+
 ## Using the factory
 
 The `CFDIFactory` allow a common way to create `CFDIReaders` using `SchemasValidator` and `PostValidator`.

--- a/src/CFDIReader/CFDICleaner.php
+++ b/src/CFDIReader/CFDICleaner.php
@@ -165,7 +165,11 @@ class CFDICleaner
     private function xpathQuery(string $query, DOMNode $element = null): DOMNodeList
     {
         $element = $element ?: $this->dom->documentElement;
-        return (new DOMXPath($element->ownerDocument))->query($query, $element);
+        $nodelist = (new DOMXPath($element->ownerDocument))->query($query, $element);
+        if (false === $nodelist) {
+            $nodelist = new DOMNodeList();
+        }
+        return $nodelist;
     }
 
     /**
@@ -200,7 +204,7 @@ class CFDICleaner
             return;
         }
         $schemaLocations = $this->xpathQuery("//@$xsi:schemaLocation");
-        if (false === $schemaLocations || $schemaLocations->length === 0) {
+        if ($schemaLocations->length === 0) {
             return;
         }
         for ($s = 0; $s < $schemaLocations->length; $s++) {

--- a/src/CFDIReader/CFDIFactory.php
+++ b/src/CFDIReader/CFDIFactory.php
@@ -119,8 +119,11 @@ class CFDIFactory
      */
     public function newCadenaOrigen(): CadenaOrigen
     {
-        $retriever = $this->newXsltRetriever();
         $cadenaOrigenBuilder = new CadenaOrigen();
+        $retriever = $this->newXsltRetriever();
+        if (null === $retriever) {
+            return $cadenaOrigenBuilder;
+        }
         foreach ($cadenaOrigenBuilder->getXsltLocations() as $version => $remote) {
             $location = $retriever->buildPath($remote);
             if (! file_exists($location)) {

--- a/src/CFDIReader/PostValidations/Validators/AbstractValidator.php
+++ b/src/CFDIReader/PostValidations/Validators/AbstractValidator.php
@@ -96,39 +96,4 @@ abstract class AbstractValidator implements ValidatorInterface
         }
         return $sum;
     }
-
-    /**
-     * Return the node in the path inside the Comprobante
-     * Returns null if the node does not exists
-     *
-     * @param string[] ...$path
-     * @return SimpleXMLElement|null
-     */
-    protected function xmlNode(string ...$path)
-    {
-        $node = $this->comprobante;
-        foreach ($path as $level) {
-            if (! isset($node->{$level})) {
-                return null;
-            }
-            $node = $node->{$level};
-        }
-        return $node;
-    }
-
-    /**
-     * Get the attribute content of a comprobante child
-     * If the node does not exists or the attribute does not exists return an empty string
-     *
-     * The last argument is the attribute name
-     *
-     * @param string[] ...$path
-     * @return string
-     */
-    protected function xmlAttr(string ...$path): string
-    {
-        $attribute = array_pop($path);
-        $node = $this->xmlNode(...$path);
-        return (null !== $node) ? (string) $node[$attribute] : '';
-    }
 }

--- a/src/CFDIReader/PostValidations/Validators/AbstractValidator.php
+++ b/src/CFDIReader/PostValidations/Validators/AbstractValidator.php
@@ -96,4 +96,39 @@ abstract class AbstractValidator implements ValidatorInterface
         }
         return $sum;
     }
+
+    /**
+     * Return the node in the path inside the Comprobante
+     * Returns null if the node does not exists
+     *
+     * @param string[] ...$path
+     * @return SimpleXMLElement|null
+     */
+    protected function xmlNode(string ...$path)
+    {
+        $node = $this->comprobante;
+        foreach ($path as $level) {
+            if (! isset($node->{$level})) {
+                return null;
+            }
+            $node = $node->{$level};
+        }
+        return $node;
+    }
+
+    /**
+     * Get the attribute content of a comprobante child
+     * If the node does not exists or the attribute does not exists return an empty string
+     *
+     * The last argument is the attribute name
+     *
+     * @param string[] ...$path
+     * @return string
+     */
+    protected function xmlAttr(string ...$path): string
+    {
+        $attribute = array_pop($path);
+        $node = $this->xmlNode(...$path);
+        return (null !== $node) ? (string) $node[$attribute] : '';
+    }
 }

--- a/src/CFDIReader/PostValidations/Validators/Certificado.php
+++ b/src/CFDIReader/PostValidations/Validators/Certificado.php
@@ -15,7 +15,7 @@ use CfdiUtils\CfdiCertificado;
  */
 class Certificado extends AbstractValidator
 {
-    /** @var CadenaOrigen */
+    /** @var CadenaOrigen|null */
     private $cadenaOrigen;
 
     public function setCadenaOrigen(CadenaOrigen $cadenaOrigen = null)

--- a/src/CFDIReader/PostValidations/Validators/Certificado.php
+++ b/src/CFDIReader/PostValidations/Validators/Certificado.php
@@ -68,7 +68,7 @@ class Certificado extends AbstractValidator
 
     private function validateNoCertificado(UtilCertificado $certificado, string $noCertificado)
     {
-        if ($certificado->getSerial() !== (string) $noCertificado) {
+        if ($certificado->getSerial() !== $noCertificado) {
             $this->errors->add(sprintf(
                 'El número del certificado extraido (%s) no coincide con el reportado en el comprobante (%s)',
                 $certificado->getSerial(),

--- a/src/CFDIReader/PostValidations/Validators/Certificado.php
+++ b/src/CFDIReader/PostValidations/Validators/Certificado.php
@@ -25,7 +25,8 @@ class Certificado extends AbstractValidator
 
     public function getCadenaOrigen(): CadenaOrigen
     {
-        if (! $this->hasCadenaOrigen()) {
+        // use this comparison instead of hasCadenaOrigen to satisfy phpstan
+        if (! ($this->cadenaOrigen instanceof CadenaOrigen)) {
             throw new \RuntimeException('The CadenaOrigen object has not been set');
         }
         return $this->cadenaOrigen;

--- a/src/CFDIReader/PostValidations/Validators/Conceptos.php
+++ b/src/CFDIReader/PostValidations/Validators/Conceptos.php
@@ -11,15 +11,20 @@ class Conceptos extends AbstractValidator
         // setup the AbstractValidator Helper class
         $this->setup($cfdi, $issues);
         // do the validation process
-        foreach ($this->comprobante->conceptos->concepto as $concepto) {
+        $nodesConcepto = $cfdi->node('conceptos', 'concepto');
+        if (null === $nodesConcepto) {
+            $this->warnings->add('El comprobante no contiene conceptos');
+            return;
+        }
+        // only get here if conceptos/concepto is not null
+        foreach ($nodesConcepto as $concepto) {
             $extended = $this->value($concepto['valorUnitario']) * $this->value($concepto['cantidad']);
             $importe = $this->value($concepto['importe']);
             if (! $this->compare($extended, $importe)) {
-                $this->warnings->add(
-                    'El importe del concepto '
-                    . $concepto['descripcion']
-                    . ' no coincide con el producto del valor unitario y el total'
-                );
+                $this->warnings->add(sprintf(
+                    'El importe del concepto %s no coincide con el producto del valor unitario y el total',
+                    $concepto['descripcion']
+                ));
             }
         }
     }

--- a/src/CFDIReader/PostValidations/Validators/Fechas.php
+++ b/src/CFDIReader/PostValidations/Validators/Fechas.php
@@ -16,12 +16,17 @@ class Fechas extends AbstractValidator
             $this->errors->add('La fecha del documento es mayor a la fecha actual');
         }
         if ($cfdi->hasTimbreFiscalDigital()) {
-            $timbrado = strtotime($this->comprobante->complemento->timbreFiscalDigital['fechaTimbrado']);
-            if ($document > $timbrado) {
-                $this->errors->add('La fecha del documento es mayor a la fecha del timbrado');
-            }
-            if ($timbrado - $document > 259200) {
-                $this->errors->add('La fecha fecha del timbrado excedió las 72 horas de la fecha del documento');
+            $timbrado = $cfdi->attribute('complemento', 'timbreFiscalDigital', 'fechaTimbrado');
+            if ('' === $timbrado) {
+                $this->errors->add('Existe un timbre pero no tiene fecha de timbrado');
+            } else {
+                $timbrado = strtotime($timbrado);
+                if ($document > $timbrado) {
+                    $this->errors->add('La fecha del documento es mayor a la fecha del timbrado');
+                }
+                if ($timbrado - $document > 259200) {
+                    $this->errors->add('La fecha fecha del timbrado excedió las 72 horas de la fecha del documento');
+                }
             }
         }
     }

--- a/src/CFDIReader/PostValidations/Validators/Totales.php
+++ b/src/CFDIReader/PostValidations/Validators/Totales.php
@@ -10,19 +10,35 @@ class Totales extends AbstractValidator
     {
         // setup the AbstractValidator Helper class
         $this->setup($cfdi, $issues);
-        // do the validation process
-        $importes = $this->sumNodes($this->comprobante->conceptos->concepto, 'importe');
-        $subtotal = $this->value($this->comprobante['subTotal']);
+
+        // obtain the sum of importes
+        $nodesConcepto = $cfdi->node('conceptos', 'concepto');
+        $importes = $this->sumNodes($nodesConcepto, 'importe');
+
+        // obtain the subtotal
+        $subtotal = $this->value($cfdi->attribute('subTotal'));
+
+        // check subtotal versus importes
         if (! $this->compare($importes, $subtotal)) {
             $this->warnings->add('El subtotal no coincide con la suma de los importes');
         }
-        $retenidos = $this->value($this->comprobante->impuestos['totalImpuestosRetenidos']);
-        $traslados = $this->value($this->comprobante->impuestos['totalImpuestosTrasladados']);
-        $localesRetenidos = $this->value($this->comprobante->complemento->impuestosLocales['totaldeRetenciones']);
-        $localesTraslados = $this->value($this->comprobante->complemento->impuestosLocales['totaldeTraslados']);
-        $descuentos = $this->value($this->comprobante['descuento']);
-        $total = $this->value($this->comprobante['total']);
-        $calculated = $subtotal - $descuentos + $traslados - $retenidos + $localesTraslados - $localesRetenidos;
+
+        // obtain retenidos and traslados
+        $retenidos = $this->value($cfdi->attribute('impuestos', 'totalImpuestosRetenidos'));
+        $traslados = $this->value($cfdi->attribute('impuestos', 'totalImpuestosTrasladados'));
+        $locRetenidos = $this->value($cfdi->attribute('complemento', 'impuestosLocales', 'totaldeRetenciones'));
+        $locTraslados = $this->value($cfdi->attribute('complemento', 'impuestosLocales', 'totalImpuestosRetenidos'));
+
+        // obtain descuentos
+        $descuentos = $this->value($cfdi->attribute('descuento'));
+
+        // calculate the amount of the total
+        $calculated = $subtotal - $descuentos + $traslados - $retenidos + $locTraslados - $locRetenidos;
+
+        // obtain the total
+        $total = $this->value($cfdi->attribute('total'));
+
+        // compare total versus calculated
         if (! $this->compare($calculated, $total)) {
             $this->warnings->add(
                 'El total no coincide con la suma del subtotal'

--- a/src/CFDIReader/SchemasValidator/SchemasValidator.php
+++ b/src/CFDIReader/SchemasValidator/SchemasValidator.php
@@ -70,9 +70,8 @@ class SchemasValidator
      */
     public function validateWithRetriever(string $content)
     {
-        if (! $this->hasRetriever()) {
-            throw new \LogicException('There are no retriever in the object');
-        }
+        // obtain the retriever, throw its own exception if non set
+        $retriever = $this->getRetriever();
         // create the schema validator object
         $validator = new SchemaValidator($content);
         // obtain the list of schemas
@@ -80,9 +79,9 @@ class SchemasValidator
         // replace with the local path
         foreach ($schemas as $schema) {
             $location = $schema->getLocation();
-            $localPath = $this->retriever->buildPath($location);
+            $localPath = $retriever->buildPath($location);
             if (! file_exists($localPath)) {
-                $this->retriever->retrieve($location);
+                $retriever->retrieve($location);
             }
             $schemas->create($schema->getNamespace(), $localPath);
         }

--- a/src/CFDIReader/SchemasValidator/SchemasValidator.php
+++ b/src/CFDIReader/SchemasValidator/SchemasValidator.php
@@ -16,7 +16,7 @@ use XmlSchemaValidator\SchemaValidator;
  */
 class SchemasValidator
 {
-    /** @var XsdRetriever */
+    /** @var XsdRetriever|null */
     private $retriever;
 
     public function __construct(XsdRetriever $retriever = null)

--- a/src/CFDIReader/SchemasValidator/SchemasValidator.php
+++ b/src/CFDIReader/SchemasValidator/SchemasValidator.php
@@ -34,7 +34,8 @@ class SchemasValidator
      */
     public function getRetriever(): XsdRetriever
     {
-        if (! $this->hasRetriever()) {
+        // use this comparison instead of hasRetriever to satisfy phpstan
+        if (! ($this->retriever instanceof XsdRetriever)) {
             throw new \LogicException('The retriever property has not been set');
         }
         return $this->retriever;

--- a/src/CFDIReader/SchemasValidator/SchemasValidator.php
+++ b/src/CFDIReader/SchemasValidator/SchemasValidator.php
@@ -78,6 +78,7 @@ class SchemasValidator
         $schemas = $validator->buildSchemas();
         // replace with the local path
         foreach ($schemas as $schema) {
+            /** @var \XmlSchemaValidator\Schema $schema */
             $location = $schema->getLocation();
             $localPath = $retriever->buildPath($location);
             if (! file_exists($localPath)) {

--- a/tests/CFDIReaderTests/CFDIReaderTest.php
+++ b/tests/CFDIReaderTests/CFDIReaderTest.php
@@ -132,4 +132,42 @@ class CFDIReaderTest extends TestCase
         $this->assertEquals($first->saveXML(), $second->saveXML());
         $this->assertNotSame($first, $second, 'Each instance of document must be different');
     }
+
+    public function testNode()
+    {
+        $filename = test_file_location('v33/valid.xml');
+        $cfdi = new CFDIReader(file_get_contents($filename));
+
+        // retrieve node
+        $this->assertInstanceOf(SimpleXMLElement::class, $cfdi->node('emisor'));
+        // retrieve non existent
+        $this->assertNull($cfdi->node('non-existent-node'));
+        // retrieve non existent inside an existent
+        $this->assertNull($cfdi->node('emisor', 'non-existent-node'));
+        // retrieve collection
+        $this->assertCount(3, $cfdi->node('conceptos', 'concepto'));
+    }
+
+    public function testNodeReturnDifferentInstances()
+    {
+        $filename = test_file_location('v33/valid.xml');
+        $cfdi = new CFDIReader(file_get_contents($filename));
+
+        $first = $cfdi->node('emisor');
+        $second = $cfdi->node('emisor');
+
+        $this->assertEquals($first, $second);
+        $this->assertNotSame($first, $second);
+    }
+
+    public function testAttribute()
+    {
+        $filename = test_file_location('v33/valid.xml');
+        $cfdi = new CFDIReader(file_get_contents($filename));
+
+        $this->assertSame('3.3', $cfdi->attribute('version'));
+        $this->assertSame('AAA010101AAA', $cfdi->attribute('emisor', 'rfc'));
+        $this->assertSame('', $cfdi->attribute('non-existent-attribute'));
+        $this->assertSame('', $cfdi->attribute('foo-bar', 'non-existent-node'));
+    }
 }


### PR DESCRIPTION
- Add `node` and `attribute` methods to `CFDIReader`. 
  This action simplify the information extraction from the `Comprobante`node.
  - `nodes` returns `NULL` or a cloned `\SimpleXmlElement` 
  - `attribute` returns a string 
- Refactor validators and `CFDIReader` to use this helpers, now is more readable and simple 
- Fix possible bug when `CFDIFactory::newXsltRetriever()` returns `NULL` 
- Fix possible bug inside `CFDICleaner::xpathQuery()` when `\DOMXPath::query` returns `FALSE` 
- Fix docblocks of object type properties that allows nulls 
- Special thanks to `phpstan/phpstan` to help me catch possible bugs 